### PR TITLE
ログイン中ユーザーの日報のひとことを一覧できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "cssbundling-rails"
 gem "bootsnap", require: false
 gem "omniauth-esa"
 gem "omniauth-rails_csrf_protection", "~> 1.0.1"
+gem "esa"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "bootsnap", require: false
 gem "omniauth-esa"
 gem "omniauth-rails_csrf_protection", "~> 1.0.1"
 gem "esa"
+gem "redcarpet"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     rake (13.0.6)
     rdoc (6.5.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     reline (0.3.8)
       io-console (~> 0.5)
     ruby2_keywords (0.0.5)
@@ -248,6 +249,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.8)
+  redcarpet
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,11 +80,21 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     erubi (1.12.0)
+    esa (2.0.0)
+      faraday (>= 2.0.1, < 3.0)
+      faraday-multipart
+      faraday-xml
+      mime-types (>= 2.6, < 4.0)
+      multi_xml (>= 0.5.5, < 1.0)
     faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday-net_http (3.0.2)
+    faraday-xml (0.2.1)
+      faraday (>= 1.10, < 3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -107,10 +117,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    multipart-post (2.3.0)
     net-imap (0.3.7)
       date
       net-protocol
@@ -227,6 +241,7 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   debug
+  esa
   jsbundling-rails
   omniauth-esa
   omniauth-rails_csrf_protection (~> 1.0.1)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,10 @@
 class PostsController < ApplicationController
+  TEAM = "everyleaf"
+
   def index
+    client = Esa::Client.new(access_token: current_user.access_token, current_team: TEAM)
+
+    response = client.posts(q: "@me category:日報")
+    @posts = response.body["posts"]
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -12,4 +12,15 @@ module PostsHelper
       return markdown.render(match_data[1].lstrip)
     end
   end
+
+  def diary_date(full_name)
+    pattern = /\/(\d{4}\/\d{2}\/\d{2})\//
+    match_data = full_name.match(pattern)
+
+    if match_data
+      return match_data[1]
+    else
+      return "日付が取得できませんでした"
+    end
+  end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,13 @@
+module PostsHelper
+  def brief_comment(daily_report_text)
+    pattern = /# ひとこと\r\n(.*?)\r\n\r\n#/m
+
+    match_data = daily_report_text.match(pattern)
+
+    if match_data[1].empty?
+      return "なし"
+    else
+      return match_data[1]
+    end
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,13 +1,15 @@
 module PostsHelper
   def brief_comment(daily_report_text)
-    pattern = /# ひとこと\r\n(.*?)\r\n\r\n#/m
+    pattern = /# ひとこと(.*?)\r\n\r\n#/m
 
     match_data = daily_report_text.match(pattern)
 
-    if match_data[1].empty?
+    if match_data[1].lstrip.empty?
       return "なし"
     else
-      return match_data[1]
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+
+      return markdown.render(match_data[1].lstrip)
     end
   end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,1 +1,16 @@
 <h1>Posts#index</h1>
+
+<div id="posts">
+  <% @posts.each do |post| %>
+    <div id="<%= post["number"] %>">
+      <p>
+        <strong>Date:</strong>
+        <%= post["created_at"] %>
+      </p>
+      <p>
+        <strong>ひとこと:</strong>
+        <%= brief_comment(post["body_md"]) %>
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,11 +5,11 @@
     <div id="<%= post["number"] %>">
       <p>
         <strong>Date:</strong>
-        <%= post["created_at"] %>
+        <%= diary_date(post["full_name"]) %>
       </p>
       <p>
         <strong>ひとこと:</strong>
-        <%= brief_comment(post["body_md"]) %>
+        <%= raw (brief_comment(post["body_md"])) %>
       </p>
     </div>
   <% end %>


### PR DESCRIPTION
## 何を解決するのか
esa API v1から記事を取得して、自分の記事のひとことを一覧表示できるようにします。
公式のクライアントライブラリ ( https://github.com/esaio/esa-ruby ) があったのでそれを使います。
cf. https://docs.esa.io/posts/102

### やること
- [x] esa-rubyをインストールする
- [x] ログイン中ユーザーの日報を取得できるようにする
- [x] ひとこと部分のみを抜き出して表示できるようにする
- [x] マークダウン形式で表示できるようにする

### メモ
* マークダウンの表示にはこのgemを使う。
  * https://github.com/vmg/redcarpet
* ハイフンによる箇条書きがうまくパースされていないが、今の状況から言って緊急性の高い問題ではないので一旦後回しにする。