### PR TITLE
render.comを使ってデプロイする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -241,6 +243,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user
+
+  before_action :basic_auth if Rails.env.production?
   before_action :require_login
 
   private
@@ -8,6 +10,12 @@ class ApplicationController < ActionController::Base
     return unless session[:user_id]
 
     @current_user ||= User.find(session[:user_id])
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |name, password|
+      name == ENV["BASIC_AUTH_NAME"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
   end
 
   def require_login

--- a/render.yml
+++ b/render.yml
@@ -1,0 +1,21 @@
+databases:
+  - name: chiritsumo-db
+    databaseName: chiritsumo_db
+    user: chiritsumo-db
+    region: singapore
+
+services:
+  - type: web
+    name: chiritsumo-db
+    env: ruby
+    region: singapore
+    plan: free
+    buildCommand: "./bin/render-build.sh"
+    startCommand: "bundle exec puma -C config/puma.rb"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: chiritsumo-db
+          property: connectionString
+      - key: RAILS_MASTER_KEY
+        sync: false


### PR DESCRIPTION
## 何を解決するのか
本番環境にデプロイできるようにします。
スケジュールを優先してインフラには[render.com](https://render.com/)を使うことにします。

### やること
- [x] Basic認証を実装する
- [x] renderのダッシュボードで設定を行う
- [x] renderの設定ファイルを追加する