### PR TITLE
コードブロックをシンタックスハイライトする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "omniauth-esa"
 gem "omniauth-rails_csrf_protection", "~> 1.0.1"
 gem "esa"
 gem "redcarpet", "~> 3.6.0"
+gem "rouge", "~> 4.1.3"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "omniauth-rails_csrf_protection", "~> 1.0.1"
 gem "esa"
 gem "redcarpet", "~> 3.6.0"
 gem "rouge", "~> 4.1.3"
+gem "sassc-rails"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
     redcarpet (3.6.0)
     reline (0.3.8)
       io-console (~> 0.5)
+    rouge (4.1.3)
     ruby2_keywords (0.0.5)
     snaky_hash (2.0.1)
       hashie
@@ -259,6 +260,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.8)
   redcarpet (~> 3.6.0)
+  rouge (~> 4.1.3)
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     faraday-net_http (3.0.2)
     faraday-xml (0.2.1)
       faraday (>= 1.10, < 3)
+    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -210,6 +211,14 @@ GEM
       io-console (~> 0.5)
     rouge (4.1.3)
     ruby2_keywords (0.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -224,6 +233,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.0.8)
     thor (1.2.2)
+    tilt (2.3.0)
     timeout (0.4.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
@@ -261,6 +271,7 @@ DEPENDENCIES
   rails (~> 7.0.8)
   redcarpet (~> 3.6.0)
   rouge (~> 4.1.3)
+  sassc-rails
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
+//= link rouge.css
 //= link_tree ../images
 //= link_tree ../builds

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -21,3 +21,11 @@
   --#{$prefix}btn-disabled-border-color: #0A9B94;
   --#{$prefix}gradient: none;
 }
+
+pre {
+  padding: 20px;
+}
+
+.highlight {
+  border-radius: 10px;
+}

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,8 +5,10 @@ class PostsController < ApplicationController
     client = Esa::Client.new(access_token: current_user.access_token, current_team: TEAM)
     response = client.posts(q: "@me category:日報", per_page: 30, page: params[:page])
 
+    post_extractor = PostExtractor.new
+
+    @posts = post_extractor.run(response.body["posts"])
     @current_page = response.body["page"]
     @next_page = response.body["next_page"]
-    @posts = response.body["posts"]
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,3 +1,9 @@
+require "rouge/plugins/redcarpet"
+
+class CustomRenderHTML < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+end
+
 module PostsHelper
   def brief_comment(daily_report_text)
     pattern = /# ひとこと(.*?)\r\n\r\n#/m
@@ -8,10 +14,8 @@ module PostsHelper
     if expected_data.empty?
       "なし"
     else
-      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, fenced_code_blocks: true)
       expected_text = expected_data.gsub("\r\n", "\r\n\r\n")
-
-      markdown.render(expected_text)
+      expected_data
     end
   end
 
@@ -24,5 +28,25 @@ module PostsHelper
     else
       return "日付が取得できませんでした"
     end
+  end
+
+  def markdown(text)
+    options = {
+      no_styles:     true,
+      with_toc_data: true,
+      hard_wrap:     true,
+    }
+    extensions = {
+      no_intra_emphasis:   true,
+      tables:              true,
+      fenced_code_blocks:  true,
+      autolink:            true,
+      lax_spacing:         true,
+      space_after_headers: true,
+    }
+
+    renderer = CustomRenderHTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -5,31 +5,6 @@ class CustomRenderHTML < Redcarpet::Render::HTML
 end
 
 module PostsHelper
-  def brief_comment(daily_report_text)
-    pattern = /# ひとこと(.*?)\r\n\r\n#/m
-
-    match_data = daily_report_text.match(pattern)
-    expected_data = match_data[1].lstrip
-
-    if expected_data.empty?
-      "なし"
-    else
-      expected_text = expected_data.gsub("\r\n", "\r\n\r\n")
-      expected_data
-    end
-  end
-
-  def diary_date(full_name)
-    pattern = /\/(\d{4}\/\d{2}\/\d{2})\//
-    match_data = full_name.match(pattern)
-
-    if match_data
-      return match_data[1]
-    else
-      return "日付が取得できませんでした"
-    end
-  end
-
   def markdown(text)
     options = {
       no_styles:     true,

--- a/app/services/post_extractor.rb
+++ b/app/services/post_extractor.rb
@@ -1,0 +1,32 @@
+class PostExtractor
+  def run(posts)
+    post_contents = posts.map do |post|
+                      { date: diary_date(post["full_name"]), body: brief_comment(post["body_md"])}
+                    end
+  end
+
+  def brief_comment(daily_report_text)
+    pattern = /# ひとこと(.*?)\r\n\r\n#/m
+
+    match_data = daily_report_text.match(pattern)
+    expected_data = match_data[1].lstrip
+
+    if expected_data.empty?
+      "なし"
+    else
+      expected_text = expected_data.gsub("\r\n", "\r\n\r\n")
+      expected_data
+    end
+  end
+
+  def diary_date(full_name)
+    pattern = /\/(\d{4}\/\d{2}\/\d{2})\//
+    match_data = full_name.match(pattern)
+
+    if match_data
+      return match_data[1]
+    else
+      return "日付が取得できませんでした"
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "rouge" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
     <% @posts.each do |post| %>
       <div class="border-bottom pt-4 pb-4" id="<%= post["number"] %>">
         <h5 class="mb-3"><%= diary_date(post["full_name"]) %></h5>
-        <p class="py-2 mb-1"><%= raw (brief_comment(post["body_md"])) %></p>
+        <p class="py-2 mb-1"><%= raw markdown((brief_comment(post["body_md"]))) %></p>
       </div>
     <% end %>
     <%= turbo_frame_tag "posts-page-#{@next_page}", loading: :lazy, src: posts_path(page: @next_page) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,8 +2,8 @@
   <%= turbo_frame_tag "posts-page-#{@current_page}" do %>
     <% @posts.each do |post| %>
       <div class="border-bottom pt-4 pb-4" id="<%= post["number"] %>">
-        <h5 class="mb-3"><%= diary_date(post["full_name"]) %></h5>
-        <p class="py-2 mb-1"><%= raw markdown((brief_comment(post["body_md"]))) %></p>
+        <h5 class="mb-3"><%= post[:date] %></h5>
+        <p class="py-2 mb-1"><%= markdown(post[:body]) %></p>
       </div>
     <% end %>
     <%= turbo_frame_tag "posts-page-#{@next_page}", loading: :lazy, src: posts_path(page: @next_page) %>


### PR DESCRIPTION
## 何を解決するのか
可読性を向上するため、シンタックスハイライトして表示できるようにします。

<img width="653" alt="スクリーンショット 2023-10-17 20 03 02" src="https://github.com/Hannosuke/chiritsumo/assets/70847530/c5fa3135-3a46-493a-ad17-8ab3883aa174">

### やること
- [x] rougeのgemをインストールする
- [x] rougeのCSSを使えるようにする
- [x] シンタックスハイライトして表示するメソッドを追加する
- [x] シンタックスハイライトして表示する