### PR TITLE
アクセストークンが無効だったら強制ログアウトさせる

### DIFF
--- a/app/services/esa_client.rb
+++ b/app/services/esa_client.rb
@@ -1,0 +1,21 @@
+class EsaClient
+  TEAM = "everyleaf"
+  PER_PAGE = 30
+  SEARCH_QUERY_KEY = "@me category:日報"
+
+  class UnauthorizedError < StandardError; end
+
+  def initialize(access_token)
+    @client = Esa::Client.new(access_token: access_token, current_team: TEAM)
+  end
+
+  def get_posts(page)
+    response = @client.posts(q: SEARCH_QUERY_KEY, per_page: PER_PAGE, page: page)
+
+    if response.status == 401
+      raise UnauthorizedError
+    end
+
+    response
+  end
+end


### PR DESCRIPTION
## 何を解決するのか
アクセストークンが無効な時、APIからは401 unauthorizedが返るようになっています。
これをハンドリングして強制ログアウトさせるようにします。

### やること
- [x] レスポンスステータスが401だったらセッションを無効化してログイン画面に遷移させる
